### PR TITLE
PD 244 Added configuration for capacitor local server

### DIFF
--- a/sicoin/config/common.py
+++ b/sicoin/config/common.py
@@ -77,6 +77,7 @@ class Common(Configuration):
     CORS_ALLOWED_ORIGINS = [
         "http://localhost:8080",
         "http://localhost:8081",
+        "http://localhost",
         "https://tesis-cabal-cugno-moreyra.onrender.com",
     ]
     CORS_ALLOWED_ORIGIN_REGEXES = [


### PR DESCRIPTION
Se agregó la connfiguración para que Cors acepte a localhost como un host válido, requerido por Capacitor.
(maldito CORS)
<img width="1420" alt="Abuelo gritandole a la nube" src="https://user-images.githubusercontent.com/21263953/110048126-fa396d80-7d2d-11eb-9e6a-53ce851b5728.png">
