### PR TITLE
PD-107 Fixes to Profile Update-Destroy

### DIFF
--- a/sicoin/users/views.py
+++ b/sicoin/users/views.py
@@ -23,9 +23,9 @@ from django.core.cache import cache
 class DestroyWitProtectedCatchMixin(mixins.DestroyModelMixin):
     def destroy(self, request, *args, **kwargs):
         try:
-            super().destroy(request, args, kwargs)
+            return super().destroy(request, args, kwargs)
         except ProtectedError:
-            Response(status=status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
 
 class UserRetrieveUpdateViewSet(mixins.UpdateModelMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
Se hacen fixes para contestar con un 400 cuando se intenta eliminar un perfil que ya tiene incidentes relacionados

![Compu](https://user-images.githubusercontent.com/21263953/111548390-6a49e980-8759-11eb-88ec-4bca8816b8aa.jpg)
