### PR TITLE
Add statistics endpoint with mocked data

### DIFF
--- a/sicoin/urls.py
+++ b/sicoin/urls.py
@@ -19,7 +19,8 @@ from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
-from .users.views import ActivateUserView, DeactivateUserView, CreateOrUpdateResourceProfileDeviceData
+from .users.views import ActivateUserView, DeactivateUserView, CreateOrUpdateResourceProfileDeviceData, \
+    StatisticsByResource
 
 router = DefaultRouter()
 router.register(r'users', views.UserCreateListViewSet)
@@ -73,6 +74,9 @@ urlpatterns = [
     path('api/v1/resources/<int:resource_id>/incidents/', IncidentResourceFromResourceListView.as_view()),
     path('api/v1/users/<uuid:user_id>/activate/', ActivateUserView.as_view()),
     path('api/v1/users/<uuid:user_id>/deactivate/', DeactivateUserView.as_view()),
+
+    path('api/v1/statistics/', StatisticsByResource.as_view()),
+
     re_path(r'^rest-auth/', include('dj_rest_auth.urls')),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('hello/', views.HelloView.as_view()),

--- a/sicoin/users/views.py
+++ b/sicoin/users/views.py
@@ -255,3 +255,124 @@ class GoogleView(APIView):
         response = {'username': user.username, 'access_token': str(token.access_token),
                     'refresh_token': str(token)}
         return HttpResponse(json.dumps(response))
+
+
+class StatisticsByResource(APIView):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        response = {
+            "barChartData": {
+                "labels": [
+                    "Campos",
+                    "Estructurales",
+                    "Vehículos",
+                    "Pastizales",
+                    "Rescates",
+                    "Accidentes",
+                    "Varios"
+                ],
+                "datasets": [
+                    {
+                        "label": "Cantidad de Incidentes",
+                        "backgroundColor": "red",
+                        "barThickness": 25,
+                        "maxBarThickness": 35,
+                        "data": [40, 39, 10, 40, 39, 80, 40]
+                    },
+                    {
+                        "label": "Cantidad de Incidentes Asistidos",
+                        "backgroundColor": "green",
+                        "barThickness": 25,
+                        "maxBarThickness": 35,
+                        "data": [4, 9, 1, 30, 29, 10, 37]
+                    }
+                ]
+            },
+            "pieChartData": {
+                "labels": [
+                    "Campos",
+                    "Estructurales",
+                    "Vehículos",
+                    "Pastizales",
+                    "Rescates",
+                    "Accidentes",
+                    "Varios"
+                ],
+                "datasets": [
+                    {
+                        "data": [40, 39, 10, 40, 39, 80, 40],
+                        "backgroundColor": [
+                            "red",
+                            "blue",
+                            "yellow",
+                            "green",
+                            "white",
+                            "orange",
+                            "purple"
+                        ]
+                    }
+                ]
+            },
+            "lineChartDataWeekly": {
+                "labels": [
+                    "Domingo",
+                    "Lunes",
+                    "Martes",
+                    "Miércoles",
+                    "Jueves",
+                    "Viernes",
+                    "Sábado"
+                ],
+                "datasets": [
+                    {
+                        "label": "Incidentes asistidos",
+                        "data": [1, 2, 0, 1, 0, 0, 1],
+                        "borderColor": "green"
+                    },
+                    {
+                        "label": "Total incidentes por día",
+                        "data": [4, 9, 1, 3, 9, 1, 3],
+                        "borderColor": "red"
+                    }
+                ]
+            },
+            "lineChartDataMonthly": {
+                "labels": [
+                    "Noviembre",
+                    "Diciembre",
+                    "Enero",
+                    "Febrero",
+                    "Marzo",
+                    "Abril"
+                ],
+                "datasets": [
+                    {
+                        "label": "Incidentes asistidos",
+                        "data": [14, 25, 22, 13, 12, 7, 10],
+                        "borderColor": "green"
+                    },
+                    {
+                        "label": "Total incidentes por mes",
+                        "data": [34, 45, 102, 30, 32, 67, 12],
+                        "borderColor": "red"
+                    }
+                ]
+            },
+            "lineChartDataAnnually": {
+                "labels": ["2019", "2020", "2021"],
+                "datasets": [
+                    {
+                        "label": "Incidentes asistidos",
+                        "data": [123, 234, 78],
+                        "borderColor": "green"
+                    },
+                    {
+                        "label": "Total incidentes por mes",
+                        "data": [354, 420, 92],
+                        "borderColor": "red"
+                    }
+                ]
+            }
+        }
+        return HttpResponse(json.dumps(response))


### PR DESCRIPTION
Agregué una vista básica con toda la response necesaria para rellenar los datos necesarios en la vista de estadísticas por recurso. Todo hardcodeado, sólo para poder dar por cerrado el frontend y no tener que tocarlo más, tanto web como mobile. Una vez finalizado el front, se procederá generar la respuesta específica por cada recurso consultado.

![image](https://user-images.githubusercontent.com/18491478/115940141-d4e7f680-a476-11eb-89af-2f55840554f0.png)
